### PR TITLE
blood_types: Add more test cases where no donors are available

### DIFF
--- a/problems/blood_types.py
+++ b/problems/blood_types.py
@@ -8,14 +8,12 @@ from problems.solutions.blood_types import survive
 logger = logging.getLogger(__name__)
 
 FUNCTION_NAME = "survive"
-INPUT_VARS = ['patient_blood_type', 'donated_blood']
-OUTPUT_VARS = ['survive']
+INPUT_VARS = ["patient_blood_type", "donated_blood"]
+OUTPUT_VARS = ["survive"]
 
 STATIC_RESOURCES = []
 
-PHYSICAL_CONSTANTS = {
-    'blood_types': ['A-', 'B-', 'AB-', 'O-', 'A+', 'B+', 'AB+', 'O+']
-}
+PHYSICAL_CONSTANTS = {"blood_types": ["A-", "B-", "AB-", "O-", "A+", "B+", "AB+", "O+"]}
 
 ATOL = {}
 RTOL = {}
@@ -27,22 +25,30 @@ class TestCaseType(TestCaseTypeEnum):
     LUCKY_ABP_PATIENT = ("Lucky AB+ patient", 1)
     SLIM_PICKINGS = ("Slim pickings (few donations)", 2)
     WELL_STOCKED = ("Well stocked hospital (many donations)", 2)
+    UNLUCKY_ONEG_PATIENT = ("Unlucky O- patient (No suitable donors available)", 1)
+    UNLUCKY_OPOS_PATIENT = ("Unlucky O+ patient (No suitable donors available)", 1)
+    UNLUCKY_ANEG_PATIENT = ("Unlucky A- patient (No suitable donors available)", 1)
+    UNLUCKY_APOS_PATIENT = ("Unlucky A+ patient (No suitable donors available)", 1)
+    UNLUCKY_BNEG_PATIENT = ("Unlucky B- patient (No suitable donors available)", 1)
+    UNLUCKY_BPOS_PATIENT = ("Unlucky B+ patient (No suitable donors available)", 1)
+    UNLUCKY_ABNEG_PATIENT = ("Unlucky AB- patient (No suitable donors available)", 1)
+    UNLUCKY_ABPOS_PATIENT = ("Unlucky AB+ patient (No suitable donors available)", 1)
 
 
 class ProblemTestCase(TestCase):
     def input_tuple(self) -> tuple:
-        return self.input['patient_blood_type'], self.input['donated_blood']
+        return self.input["patient_blood_type"], self.input["donated_blood"]
 
     def output_tuple(self) -> tuple:
-        return self.output['survive'],
+        return (self.output["survive"],)
 
     def output_str(self) -> str:
-        return str(self.output['survive'])
+        return str(self.output["survive"])
 
 
 def generate_test_case(test_type: TestCaseType) -> ProblemTestCase:
     test_case = ProblemTestCase(test_type)
-    blood_types = PHYSICAL_CONSTANTS['blood_types']
+    blood_types = PHYSICAL_CONSTANTS["blood_types"]
 
     if test_type is TestCaseType.NO_DONATIONS:
         patient_blood_type = choice(blood_types)
@@ -50,10 +56,10 @@ def generate_test_case(test_type: TestCaseType) -> ProblemTestCase:
 
     elif test_type is TestCaseType.LUCKY_PATIENT:
         patient_blood_type = choice(blood_types)
-        donated_blood = ['O-', 'O-', 'O-']
+        donated_blood = ["O-", "O-", "O-"]
 
     elif test_type is TestCaseType.LUCKY_ABP_PATIENT:
-        patient_blood_type = 'AB+'
+        patient_blood_type = "AB+"
         donated_blood = [choice(blood_types)]
 
     elif test_type is TestCaseType.SLIM_PICKINGS:
@@ -64,12 +70,44 @@ def generate_test_case(test_type: TestCaseType) -> ProblemTestCase:
         patient_blood_type = choice(blood_types)
         donated_blood = choices(blood_types, k=randint(8, 25))
 
-    test_case.input = {
-        'patient_blood_type': patient_blood_type,
-        'donated_blood': donated_blood
-    }
+    elif test_type is TestCaseType.UNLUCKY_ONEG_PATIENT:
+        patient_blood_type = "O-"
+        donated_blood = ["A-", "B-", "AB-", "A+", "B+", "AB+", "O+"]
 
-    test_case.output['survive'] = survive(patient_blood_type, donated_blood)
+    elif test_type is TestCaseType.UNLUCKY_OPOS_PATIENT:
+        patient_blood_type = "O+"
+        donated_blood = ["A-", "B-", "AB-", "A+", "B+", "AB+"]
+
+    elif test_type is TestCaseType.UNLUCKY_ANEG_PATIENT:
+        patient_blood_type = "A-"
+        donated_blood = ["B-", "AB-", "A+", "B+", "AB+", "O+"]
+
+    elif test_type is TestCaseType.UNLUCKY_APOS_PATIENT:
+        patient_blood_type = "A+"
+        donated_blood = ["B-", "AB-", "B+", "AB+"]
+
+    elif test_type is TestCaseType.UNLUCKY_BNEG_PATIENT:
+        patient_blood_type = "B-"
+        donated_blood = ["A-", "AB-", "A+", "B+", "AB+", "O+"]
+
+    elif test_type is TestCaseType.UNLUCKY_BPOS_PATIENT:
+        patient_blood_type = "B+"
+        donated_blood = ["A-", "AB-", "A+", "AB+"]
+
+    elif test_type is TestCaseType.UNLUCKY_ABNEG_PATIENT:
+        patient_blood_type = "AB-"
+        donated_blood = ["A+", "B+", "AB+", "O+"]
+
+    elif test_type is TestCaseType.UNLUCKY_ABPOS_PATIENT:
+        patient_blood_type = "AB+"
+        donated_blood = []
+
+    else:
+        raise ValueError("Unrecognized test case: {}".format(test_type))
+
+    test_case.input = {"patient_blood_type": patient_blood_type, "donated_blood": donated_blood}
+
+    test_case.output["survive"] = survive(patient_blood_type, donated_blood)
 
     return test_case
 


### PR DESCRIPTION
More tests for blood types (#42) so we cover more cases where the result should be False. 

Also raise a clearer error in case the test case enum is not recognized (this should probably be used in other tests too, but that can be a separate PR). 